### PR TITLE
alt: Remove -DLIBRARY_INSTALL_DIRECTORY

### DIFF
--- a/sci-misc/alt/alt-9999.ebuild
+++ b/sci-misc/alt/alt-9999.ebuild
@@ -28,7 +28,7 @@ src_prepare() {
 }
 
 src_configure() {
-	cmake .. -DBUILD_TYPE=Release -DLIBRARY_INSTALL_DIRECTORY=lib64 || die
+	cmake .. -DBUILD_TYPE=Release  || die
 }
 
 #src_compile() {


### PR DESCRIPTION
This option is now useless. See https://gitlab.fit.cvut.cz/algorithms-library-toolkit/automata-library/issues/187 for more info.